### PR TITLE
Update local-check.yaml

### DIFF
--- a/.github/workflows/local-check.yaml
+++ b/.github/workflows/local-check.yaml
@@ -27,9 +27,6 @@ jobs:
           --std=c++11 \
           --enable=all \
           --inline-suppr \
-          #--suppress=unmatchedSuppression \
-          #--suppress=unusedFunction \
-          #--suppress=missingInclude \
           ${{ github.workspace }}
 
   build:
@@ -37,34 +34,27 @@ jobs:
       - lint   #se ci sono errori non provo nemmeno a buildare
       - cppcheck
     runs-on: self-hosted
-    #TODO: va controllato che ogni volta che questo workflow parte, le cartelel di destinazione vengono azzerate o i file persistono
     steps:
       - uses: actions/checkout@v4
       - name: Set reusable strings
-        # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
         id: strings
         shell: bash
         run: |
             echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
 
       - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
         run: >
             cmake -B ${{ steps.strings.outputs.build-output-dir }} 
-            -DCMAKE_CXX_COMPILER=${{ g++ }} 
-            -DCMAKE_C_COMPILER=${{ gcc }} 
-            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} 
+            -DCMAKE_CXX_COMPILER=g++ 
+            -DCMAKE_C_COMPILER=gcc 
+            -DCMAKE_BUILD_TYPE=Release 
             -S ${{ github.workspace }}
 
       - name: Build
-        # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
-        run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
+        run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config Release
 
       - name: Test
         working-directory: ${{ steps.strings.outputs.build-output-dir }}
-        # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
-        # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
         run: ctest --build-config Release
 
   documentation:


### PR DESCRIPTION
1. Uso di g++ e gcc come stringhe esplicite:

    Sostituito ${{ g++ }} con g++ e ${{ gcc }} con gcc nella configurazione di CMake.

2. Rimosso matrix.build_type:

    Nella configurazione di CMake e nei comandi di build/test, ho specificato direttamente il tipo di build come Release. Se hai necessità di supportare altri tipi di build (ad esempio Debug), puoi reintrodurre una matrice nel workflow.

3. Pulizia generale:

    Rimosso il commento errato o non utilizzato nella sezione cppcheck.
    Ottimizzati alcuni comandi per renderli più chiari e comprensibili.